### PR TITLE
Rearrange dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ We run some tests to figure out an acceptable sample rate for the motion analysi
 
 We performed a few motion analysis for the same one minute video with different sample rates. The results can be seen in the graph below (the x axis is time, while the y axis indicates the motion difference between two samples, ranging from 0 to 1). The video used for testing has two cuts, around second 6 and second 20.
 
-![Sample rates graph](sample_rates_for_motion.png) 
+![Sample rates graph](sample_rates_for_motion.png)
 
 - For 2000 ms, the analysis took 8.143 s (13.6% of the video duration)
 - For 1000 ms, the analysis took 17.119 s (28.5% of the video duration)
@@ -30,6 +30,21 @@ We performed a few motion analysis for the same one minute video with different 
 - For 100 ms, the analysis took 182.665 s (304% of the video duration)
 
 We concluded that getting a frame every half second (500 ms) will be good enough for our application. This conclusion is however susceptible of being revisited in the future.
+
+
+## Get it running
+
+Before you can run FilmViz you need to install the `npm` and `bower` dependencies. Execute this commands on a terminal:
+```
+npm install
+bower install
+```
+(You need to [install](https://nodejs.org/download/) `node.js` for `npm` and run `npm install bower -g` for `bower`)
+
+That's it! Now you can run an static HTTP server and enjoy FilmViz.
+```
+python -m SimpleHTTPServer 8000  # Go to http://0.0.0.0:8000/
+```
 
 
 ## Documentation

--- a/bower.json
+++ b/bower.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "homepage": "https://github.com/surreal6/filmviz",
   "main": "index.html",
-  "license": "GPLv3",
+  "license": "GPL-3.0",
   "ignore": [
     "**/.*",
     "node_modules",

--- a/bower.json
+++ b/bower.json
@@ -12,6 +12,10 @@
     "tests"
   ],
   "dependencies": {
-    "jszip": "~2.5.0"
+    "jszip": "~2.5.0",
+    "angular": "~1.4.3",
+    "angular-route": "~1.4.3",
+    "bootstrap": "~3.3.5",
+    "resemblejs": "~1.3.0"
   }
 }

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 
 <head>
   <meta charset="UTF-8">
-  <link rel="stylesheet" href="node_modules/bootstrap/dist/css/bootstrap.min.css">
+  <link rel="stylesheet" href="bower_components/bootstrap/dist/css/bootstrap.min.css">
   <link rel="stylesheet" href="css/style.css">
   <title></title>
 </head>
@@ -16,20 +16,21 @@
 
   <div ng-view class="row"></div>
 
-  <!-- Include the AngularJS library -->
-  <script src="node_modules/angular/angular.min.js"></script>
-  <script src="node_modules/angular-route/angular-route.min.js"></script>
-  <!-- Include our libraries -->
+  <!-- Vendor libraries -->
+  <script src="bower_components/angular/angular.min.js"></script>
+  <script src="bower_components/angular-route/angular-route.min.js"></script>
+  <script src="bower_components/jszip/dist/jszip.min.js"></script>
+  <script src="node_modules/rgbquant/src/rgbquant.js"></script>
+
+  <!-- FilmViz libraries -->
   <script src="js/app.js"></script>
   <script src="js/timecodeUtils.js"></script>
   <script src="js/fileUtils.js"></script>
   <script src="js/colorAnalyzer.js"></script>
-  <!-- Include Vendor libraries -->
-  <script src="node_modules/rgbquant/src/rgbquant.js"></script>
-  <script src="bower_components/jszip/dist/jszip.min.js"></script>
-  <!-- Include Controllers -->
+
+  <!-- Angular Controllers -->
   <script src="js/controllers/ProjectController.js"></script>
-  <!-- Include Directives -->
+  <!-- Angular Directives -->
   <script src="js/directives/tabNavigation.js"></script>
   <script src="js/directives/metadataEditor.js"></script>
   <script src="js/directives/metadataTags.js"></script>

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "url": "git://github.com/surreal6/filmviz.git"
   },
   "author": "",
-  "license": "GPLv3",
+  "license": "GPL-3.0",
   "bugs": {
     "url": "https://github.com/surreal6/filmviz/issues"
   }

--- a/package.json
+++ b/package.json
@@ -4,11 +4,6 @@
   "description": "",
   "main": "index.html",
   "dependencies": {
-    "angular": "^1.4.3",
-    "angular-route": "^1.4.3",
-    "bootstrap": "^3.3.5",
-    "jszip": "^2.5.0",
-    "resemblejs": "^1.3.0",
     "rgbquant": "^1.1.1"
   },
   "devDependencies": {},


### PR DESCRIPTION
Closes #40.
Don't forget to `npm install && bower install`.
To get rid of obsolete dependencies on you disks, you can run `npm prune && bower prune`.